### PR TITLE
Add Dockerfile for simple dochunt-check image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine:latest
+ADD https://github.com/antham/doc-hunt/releases/download/v2.1.1/doc-hunt_linux_amd64 /usr/bin/doc-hunt
+RUN chmod +x /usr/bin/doc-hunt


### PR DESCRIPTION
Useful for docker-based CI (for example Gitlab CI)


